### PR TITLE
info.plist: add NSCameraUsageDescription

### DIFF
--- a/ZoomSDKSample/ZoomSDKSample/Info.plist
+++ b/ZoomSDKSample/ZoomSDKSample/Info.plist
@@ -31,6 +31,8 @@
 	</dict>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2016 TOTTI. All rights reserved.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>$(PRODUCT_NAME) camera use</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
This allows the app to work on 10.14, otherwise it crashes.